### PR TITLE
Create basic ModInterop class

### DIFF
--- a/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
+++ b/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
@@ -139,7 +139,7 @@ public sealed class SaveLoadAction {
     }
 
     // ReSharper disable once MemberCanBePrivate.Global
-    private static void LoadStaticMemberValues(Dictionary<Type, Dictionary<string, object>> values) {
+    public static void LoadStaticMemberValues(Dictionary<Type, Dictionary<string, object>> values) {
         foreach (KeyValuePair<Type, Dictionary<string, object>> pair in values) {
             foreach (string memberName in pair.Value.Keys) {
                 Type type = pair.Key;

--- a/SpeedrunTool/Source/SpeedrunToolInterop.cs
+++ b/SpeedrunTool/Source/SpeedrunToolInterop.cs
@@ -1,0 +1,21 @@
+using Celeste.Mod.SpeedrunTool.SaveLoad;
+using MonoMod.ModInterop;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.SpeedrunTool;
+
+public static class SpeedrunToolInterop {
+    [Load]
+    private static void Initialize() {
+        typeof(SaveLoadExports).ModInterop();
+    }
+
+    [ModExportName("SpeedrunTool.SaveLoad")]
+    public static class SaveLoadExports {
+        public static void RegisterStaticTypes(Type t, params string[] memberNames) {
+            SaveLoadAction.SafeAdd(
+                (savedValues, _) => SaveLoadAction.SaveStaticMemberValues(savedValues, t, memberNames),
+                (savedValues, _) => SaveLoadAction.LoadStaticMemberValues(savedValues));
+        }
+    }
+}


### PR DESCRIPTION
Just adds a simple way to register static types not automatically saved/reloaded. Makes `LoadStaticMemberValues` public so it can be used as well.

You mentioned an API for instance fields as well, but doesn't look like you have a standard way of doing that currently, not sure how you wanted that to be set up but can be easily added.

To use a ModInterop API function, the user will need to add an optional dependency for the version the function was added. 