### PR TITLE
Fix Engine.TimeRate == 0.25f if CelesteNet EmoteWheel open during savestate creation

### DIFF
--- a/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
+++ b/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -600,6 +600,11 @@ public sealed class SaveLoadAction {
 
                     foreach (Entity entity in level.Entities.Where(entity =>
                                  entity.GetType().FullName?.StartsWith("Celeste.Mod.CelesteNet.") == true)) {
+                        if (ModUtils.GetType("CelesteNet.Client", "Celeste.Mod.CelesteNet.Client.Entities.GhostEmoteWheel") is { } ghostEmoteWheelType
+                        && entity.GetType() == ghostEmoteWheelType && entity.GetFieldValue<bool>("timeRateSet")) {
+                            // Normally GhostEmoteWheel in CelesteNet does this when it gets closed again
+                            Engine.TimeRate = 1f;
+                        }
                         entity.RemoveSelf();
                     }
 


### PR DESCRIPTION
I fixed a bug related to CelesteNet, which I saw in a Parrot Dash video. :D 

https://youtu.be/6Pj5Wwrwb2k

At around 3:40 he's very confused that his savestate is permanently in slow motion, and someone smart in chat was very quick to point out CelesteNet's EmoteWheel.
The logic in the emote wheel class is a bit hacky itself, really, and it just keeps track of whether it has slowed down time to 0.25f and sets it back to 1.0f when it gets closed.

So this patch uses the existing `foreach` loop over CelesteNet entities in the `beforeSaveState` Action added with `ExternalAction`. Attempting to get the `GhostEmoteWheel` type, checking if the entity is of that type, querying its `timeRateSet` property from CelesteNet, and subsequently resetting `Engine.TimeRate` if all this was the case. :)