### PR TITLE
Add ability to export room timer data + add best segment tracking

### DIFF
--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -98,7 +98,7 @@ SPEEDRUN_TOOL_ALREADY_LAST_ROOM_DIALOG_BADELINE=
 SPEEDRUN_TOOL_SWITCH_AUTO_LOAD_STATE=        Toggle Auto Load State
 SPEEDRUN_TOOL_SPAWN_TOWER_VIEWER=            Spawn Tower Viewer
 SPEEDRUN_TOOL_TOGGLE_FULLSCREEN=             Toggle Fullscreen
-SPEEDRUN_TOOL_EXPORT_ROOM_TIMES=               Export Room Times
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES=             Export Room Times
 SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_TOOLTIP= Times successfully exported
 SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG=
     [Madeline left normal]
@@ -106,7 +106,7 @@ SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG=
 SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG_BADELINE=
     [Badeline left normal]
     Times successfully exported.
-SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_TOOLTIP=  Must be in a level to export room times
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_TOOLTIP= Must be in a level to export room times
 SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_DIALOG=
     [Madeline left upset]
     Must be in a level to export room times.

--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -98,21 +98,21 @@ SPEEDRUN_TOOL_ALREADY_LAST_ROOM_DIALOG_BADELINE=
 SPEEDRUN_TOOL_SWITCH_AUTO_LOAD_STATE=        Toggle Auto Load State
 SPEEDRUN_TOOL_SPAWN_TOWER_VIEWER=            Spawn Tower Viewer
 SPEEDRUN_TOOL_TOGGLE_FULLSCREEN=             Toggle Fullscreen
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES=               Dump Room Times
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_TOOLTIP= Times successfully dumped
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG=
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES=               Export Room Times
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_TOOLTIP= Times successfully exported
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG=
     [Madeline left normal]
-    Times successfully dumped.
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG_BADELINE=
+    Times successfully exported.
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG_BADELINE=
     [Badeline left normal]
-    Times successfully dumped.
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_TOOLTIP=  Must be in a level to dump room times
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG=
+    Times successfully exported.
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_TOOLTIP=  Must be in a level to export room times
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_DIALOG=
     [Madeline left upset]
-    Must be in a level to dump room times.
-SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG_BADELINE=
+    Must be in a level to export room times.
+SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_DIALOG_BADELINE=
     [Badeline left yell]
-    Must be in a level to dump room times!
+    Must be in a level to export room times!
 
 # ================================== Death Statistics ==================================
 SPEEDRUN_TOOL_DEATH_STATISTICS=              Death Statistics

--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -23,6 +23,7 @@ SPEEDRUN_TOOL_RESET_ROOM_TIMER_PB_TOOLTIP= Cleared Room Timer PB and End Point
 SPEEDRUN_TOOL_RESET_ROOM_TIMER_PB_DIALOG=
     [MADELINE left normal]
     Cleared room timer PB and end point~
+SPEEDRUN_TOOL_DISPLAY_ROOM_GOLD=           Gold Timer when Best Room Time
 
 # ================================== State ==================================
 SPEEDRUN_TOOL_FREEZE_AFTER_LOAD_STATE=     Pause The Game after Loading State

--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -98,6 +98,21 @@ SPEEDRUN_TOOL_ALREADY_LAST_ROOM_DIALOG_BADELINE=
 SPEEDRUN_TOOL_SWITCH_AUTO_LOAD_STATE=        Toggle Auto Load State
 SPEEDRUN_TOOL_SPAWN_TOWER_VIEWER=            Spawn Tower Viewer
 SPEEDRUN_TOOL_TOGGLE_FULLSCREEN=             Toggle Fullscreen
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES=               Dump Room Times
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_TOOLTIP= Times successfully dumped
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG=
+    [Madeline left normal]
+    Times successfully dumped.
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG_BADELINE=
+    [Badeline left normal]
+    Times successfully dumped.
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_TOOLTIP=  Must be in a level to dump room times
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG=
+    [Madeline left upset]
+    Must be in a level to dump room times.
+SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG_BADELINE=
+    [Badeline left yell]
+    Must be in a level to dump room times!
 
 # ================================== Death Statistics ==================================
 SPEEDRUN_TOOL_DEATH_STATISTICS=              Death Statistics

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -94,13 +94,13 @@ public static class DialogIds {
     public const string SwitchAutoLoadState = "SPEEDRUN_TOOL_SWITCH_AUTO_LOAD_STATE";
     public const string SpawnTowerViewer = "SPEEDRUN_TOOL_SPAWN_TOWER_VIEWER";
     public const string ToggleFullscreen = "SPEEDRUN_TOOL_TOGGLE_FULLSCREEN";
-    public const string DumpRoomTimes = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES";
-    public const string DumpRoomTimesSuccessTooltip = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_TOOLTIP";
-    public const string DumpRoomTimesSuccessDialog = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG";
-    public const string DumpRoomTimesSuccessDialogBadeline = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG_BADELINE";
-    public const string DumpRoomTimesFailTooltip = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_TOOLTIP";
-    public const string DumpRoomTimesFailDialog = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG";
-    public const string DumpRoomTimesFailDialogBadeline = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG_BADELINE";
+    public const string ExportRoomTimes = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES";
+    public const string ExportRoomTimesSuccessTooltip = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_TOOLTIP";
+    public const string ExportRoomTimesSuccessDialog = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG";
+    public const string ExportRoomTimesSuccessDialogBadeline = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_SUCCESS_DIALOG_BADELINE";
+    public const string ExportRoomTimesFailTooltip = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_TOOLTIP";
+    public const string ExportRoomTimesFailDialog = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_DIALOG";
+    public const string ExportRoomTimesFailDialogBadeline = "SPEEDRUN_TOOL_EXPORT_ROOM_TIMES_FAIL_DIALOG_BADELINE";
 
     // Death Statistics
     public const string MaxNumberOfDeathData = "SPEEDRUN_TOOL_MAX_NUMBER_OF_DEATH_DATA";

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -23,6 +23,7 @@ public static class DialogIds {
     public const string TimeHeartCassette = "SPEEDRUN_TOOL_TIME_HEART_CASSETTE";
     public const string AutoTurnOffRoomTimer = "SPEEDRUN_TOOL_AUTO_TURN_OFF_ROOM_TIMER";
     public const string RoomIdEndPoint = "SPEEDRUN_TOOL_ROOM_ID_END_POINT";
+    public const string DisplayRoomGold = "SPEEDRUN_TOOL_DISPLAY_ROOM_GOLD";
 
     // Mod Options
     public const string SpeedrunTool = "SPEEDRUN_TOOL";

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -94,6 +94,13 @@ public static class DialogIds {
     public const string SwitchAutoLoadState = "SPEEDRUN_TOOL_SWITCH_AUTO_LOAD_STATE";
     public const string SpawnTowerViewer = "SPEEDRUN_TOOL_SPAWN_TOWER_VIEWER";
     public const string ToggleFullscreen = "SPEEDRUN_TOOL_TOGGLE_FULLSCREEN";
+    public const string DumpRoomTimes = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES";
+    public const string DumpRoomTimesSuccessTooltip = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_TOOLTIP";
+    public const string DumpRoomTimesSuccessDialog = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG";
+    public const string DumpRoomTimesSuccessDialogBadeline = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_SUCCESS_DIALOG_BADELINE";
+    public const string DumpRoomTimesFailTooltip = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_TOOLTIP";
+    public const string DumpRoomTimesFailDialog = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG";
+    public const string DumpRoomTimesFailDialogBadeline = "SPEEDRUN_TOOL_DUMP_ROOM_TIMES_FAIL_DIALOG_BADELINE";
 
     // Death Statistics
     public const string MaxNumberOfDeathData = "SPEEDRUN_TOOL_MAX_NUMBER_OF_DEATH_DATA";

--- a/SpeedrunTool/Source/Other/HotkeyConfigUi.cs
+++ b/SpeedrunTool/Source/Other/HotkeyConfigUi.cs
@@ -83,7 +83,7 @@ public class HotkeyConfigUi : TextMenu {
         new(Hotkey.SwitchAutoLoadState),
         new(Hotkey.SpawnTowerViewer),
         new(Hotkey.ToggleFullscreen),
-        new(Hotkey.DumpRoomTimes),
+        new(Hotkey.ExportRoomTimes),
     }.ToDictionary(info => info.Hotkey, info => info);
 
     private bool closing;
@@ -482,7 +482,7 @@ public enum Hotkey {
     SwitchAutoLoadState,
     SpawnTowerViewer,
     ToggleFullscreen,
-    DumpRoomTimes,
+    ExportRoomTimes,
 }
 
 internal static class HotkeysExtensions {

--- a/SpeedrunTool/Source/Other/HotkeyConfigUi.cs
+++ b/SpeedrunTool/Source/Other/HotkeyConfigUi.cs
@@ -83,6 +83,7 @@ public class HotkeyConfigUi : TextMenu {
         new(Hotkey.SwitchAutoLoadState),
         new(Hotkey.SpawnTowerViewer),
         new(Hotkey.ToggleFullscreen),
+        new(Hotkey.DumpRoomTimes),
     }.ToDictionary(info => info.Hotkey, info => info);
 
     private bool closing;
@@ -481,6 +482,7 @@ public enum Hotkey {
     SwitchAutoLoadState,
     SpawnTowerViewer,
     ToggleFullscreen,
+    DumpRoomTimes,
 }
 
 internal static class HotkeysExtensions {

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
@@ -31,6 +31,9 @@ internal class RoomTimerData {
     private bool IsNextRoomType => roomTimerType == RoomTimerType.NextRoom;
     public bool IsCompleted => timerState == TimerState.Completed;
     public bool BeatBestTime => IsCompleted && (GetSelectedRoomTime < GetSelectedLastPbTime || GetSelectedLastPbTime == 0);
+    public Dictionary<string, long> GetThisRunTimes => thisRunTimes;
+    public Dictionary<string, long> GetPbTimes => pbTimes;
+    public string GetTimeKeyPrefix => timeKeyPrefix;
 
     private void UpdateTimeKeys(Level level) {
         if (timeKeyPrefix == "") {
@@ -171,7 +174,7 @@ internal class RoomTimerData {
         lastPbTimes.Clear();
     }
 
-    private static string FormatTime(long time, bool isPbTime) {
+    public static string FormatTime(long time, bool isPbTime) {
         if (time == 0 && isPbTime) {
             return "";
         }

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -312,7 +312,7 @@ public static class RoomTimerManager {
 
     public static void DumpRoomTimes() {
         RoomTimerData roomTimerData = (ModSettings.RoomTimerType is RoomTimerType.NextRoom) ? NextRoomTimerData : CurrentRoomTimerData;
-        string timeKeyPrefix = roomTimerData.GetTimeKeyPrefix;
+        string timeKeyPrefix = roomTimerData.TimeKeyPrefix;
         long lastSplitTime = 0;
 
         StringBuilder sb = new();
@@ -320,14 +320,14 @@ public static class RoomTimerManager {
         // Header row
         sb.Append("Room Number,Split,Segment,Best Split");
 
-        for (int roomNumber = 1; roomNumber <= Math.Max(roomTimerData.GetThisRunTimes.Count, roomTimerData.GetPbTimes.Count); roomNumber++) {
+        for (int roomNumber = 1; roomNumber <= Math.Max(roomTimerData.ThisRunTimes.Count, roomTimerData.PbTimes.Count); roomNumber++) {
             string timeKey = timeKeyPrefix + roomNumber;
 
             // Room Number
             sb.Append($"\n{roomNumber},");
 
             // Split,Segment
-            if (roomTimerData.GetThisRunTimes.TryGetValue(timeKey, out long splitTime)) {
+            if (roomTimerData.ThisRunTimes.TryGetValue(timeKey, out long splitTime)) {
                 sb.Append($"{RoomTimerData.FormatTime(splitTime, false)},{RoomTimerData.FormatTime(splitTime - lastSplitTime, false)},");
                 lastSplitTime = splitTime;
             } else {
@@ -335,7 +335,7 @@ public static class RoomTimerManager {
             }
 
             // Best Split
-            if (roomTimerData.GetPbTimes.TryGetValue(timeKey, out long pbTime)) {
+            if (roomTimerData.PbTimes.TryGetValue(timeKey, out long pbTime)) {
                 sb.Append(RoomTimerData.FormatTime(pbTime, false));
             }
         }

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -95,12 +95,12 @@ public static class RoomTimerManager {
         Hotkey.SetEndPoint.RegisterPressedAction(scene => EndPoint.SetEndPoint(scene, false));
         Hotkey.SetAdditionalEndPoint.RegisterPressedAction(scene => EndPoint.SetEndPoint(scene, true));
 
-        Hotkey.DumpRoomTimes.RegisterPressedAction(scene => {
+        Hotkey.ExportRoomTimes.RegisterPressedAction(scene => {
             if (scene is Level) {
-                DumpRoomTimes();
-                PopupMessageUtils.Show(DialogIds.DumpRoomTimesSuccessTooltip.DialogClean(), DialogIds.DumpRoomTimesSuccessDialog);
+                ExportRoomTimes();
+                PopupMessageUtils.Show(DialogIds.ExportRoomTimesSuccessTooltip.DialogClean(), DialogIds.ExportRoomTimesSuccessDialog);
             } else {
-                PopupMessageUtils.Show(DialogIds.DumpRoomTimesFailTooltip.DialogClean(), DialogIds.DumpRoomTimesFailDialog);
+                PopupMessageUtils.Show(DialogIds.ExportRoomTimesFailTooltip.DialogClean(), DialogIds.ExportRoomTimesFailDialog);
             }
         });
     }
@@ -310,7 +310,7 @@ public static class RoomTimerManager {
         }
     }
 
-    public static void DumpRoomTimes() {
+    public static void ExportRoomTimes() {
         RoomTimerData roomTimerData = (ModSettings.RoomTimerType is RoomTimerType.NextRoom) ? NextRoomTimerData : CurrentRoomTimerData;
         string timeKeyPrefix = roomTimerData.TimeKeyPrefix;
         long lastSplitTime = 0;
@@ -340,19 +340,19 @@ public static class RoomTimerManager {
             }
         }
 
-        Directory.CreateDirectory(Path.Combine(Everest.PathGame, "SRToolTimeDumps"));
-        using (StreamWriter writer = File.CreateText(Path.Combine(Everest.PathGame, "SRToolTimeDumps", $"{DateTime.Now:yyyyMMdd_HHmmss}.csv"))) {
+        Directory.CreateDirectory(Path.Combine(Everest.PathGame, "SRTool_RoomTimeExports"));
+        using (StreamWriter writer = File.CreateText(Path.Combine(Everest.PathGame, "SRTool_RoomTimeExports", $"{DateTime.Now:yyyyMMdd_HHmmss}.csv"))) {
             writer.WriteLine(sb.ToString());
         };
     }
 
-    [Command("srt_dumproomtimes", "dump room timer data to a .csv file")]
-    public static void CmdDumpRoomTimes() {
+    [Command("srt_exportroomtimes", "export room timer data to a .csv file")]
+    public static void CmdExportRoomTimes() {
         if (Engine.Scene is Level) {
-            DumpRoomTimes();
-            Engine.Commands.Log(DialogIds.DumpRoomTimesSuccessTooltip.DialogClean());
+            ExportRoomTimes();
+            Engine.Commands.Log(DialogIds.ExportRoomTimesSuccessTooltip.DialogClean());
         } else {
-            Engine.Commands.Log(DialogIds.DumpRoomTimesFailTooltip.DialogClean());
+            Engine.Commands.Log(DialogIds.ExportRoomTimesFailTooltip.DialogClean());
         }
     }
 }

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -318,9 +318,9 @@ public static class RoomTimerManager {
         StringBuilder sb = new();
 
         // Header row
-        sb.Append("Room Number,Split,Segment,Best Split");
+        sb.Append("Room Number,Split,Segment,Best Split,Best Segment");
 
-        for (int roomNumber = 1; roomNumber <= Math.Max(roomTimerData.ThisRunTimes.Count, roomTimerData.PbTimes.Count); roomNumber++) {
+        for (int roomNumber = 1; roomNumber <= Math.Max(roomTimerData.ThisRunTimes.Count, Math.Max(roomTimerData.PbTimes.Count, roomTimerData.BestSegments.Count)); roomNumber++) {
             string timeKey = timeKeyPrefix + roomNumber;
 
             // Room Number
@@ -334,9 +334,16 @@ public static class RoomTimerManager {
                 sb.Append(",,");
             }
 
-            // Best Split
+            // Best Split,
             if (roomTimerData.PbTimes.TryGetValue(timeKey, out long pbTime)) {
-                sb.Append(RoomTimerData.FormatTime(pbTime, false));
+                sb.Append($"{RoomTimerData.FormatTime(pbTime, false)},");
+            } else {
+                sb.Append(",");
+            }
+
+            // Best Segment
+            if (roomTimerData.BestSegments.TryGetValue(timeKey, out long bestSegment)) {
+                sb.Append(RoomTimerData.FormatTime(bestSegment, false));
             }
         }
 

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -375,5 +375,6 @@ public static class RoomTimerManager {
             Engine.Commands.Log(DialogIds.ExportRoomTimesSuccessTooltip.DialogClean());
         } else {
             Engine.Commands.Log(DialogIds.ExportRoomTimesFailTooltip.DialogClean());
+        }
     }
 }

--- a/SpeedrunTool/Source/SpeedrunToolMenu.cs
+++ b/SpeedrunTool/Source/SpeedrunToolMenu.cs
@@ -74,6 +74,9 @@ public static class SpeedrunToolMenu {
 
                 subMenu.Add(new TextMenu.OnOff(Dialog.Clean(DialogIds.AutoTurnOffRoomTimer), ModSettings.AutoResetRoomTimer).Change(b =>
                     ModSettings.AutoResetRoomTimer = b));
+
+                subMenu.Add(new TextMenu.OnOff(Dialog.Clean(DialogIds.DisplayRoomGold), ModSettings.DisplayRoomGold).Change(b =>
+                    ModSettings.DisplayRoomGold = b));
             }),
 
             new EaseInSubMenu(Dialog.Clean(DialogIds.State), false).With(subMenu => {

--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -25,6 +25,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public bool TimeSummitFlag { get; set; } = true;
     public bool TimeHeartCassette { get; set; } = true;
     public bool AutoResetRoomTimer { get; set; } = true;
+    public bool DisplayRoomGold { get; set; } = true;
 
     #endregion
 

--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -80,6 +80,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public List<Keys> KeyboardSwitchAutoLoadState { get; set; } = Hotkey.SwitchAutoLoadState.GetDefaultKeys();
     public List<Keys> KeyboardSpawnTowerViewer { get; set; } = Hotkey.SpawnTowerViewer.GetDefaultKeys();
     public List<Keys> KeyboardToggleFullscreen { get; set; } = Hotkey.ToggleFullscreen.GetDefaultKeys();
+    public List<Keys> KeyboardDumpRoomTimes { get; set; } = Hotkey.DumpRoomTimes.GetDefaultKeys();
 
     public List<Buttons> ControllerToggleHotkeys { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerSaveState { get; set; } = new List<Buttons>();
@@ -100,6 +101,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public List<Buttons> ControllerSwitchAutoLoadState { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerSpawnTowerViewer { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerToggleFullscreen { get; set; } = new List<Buttons>();
+    public List<Buttons> ControllerDumpRoomTimes { get; set; }  = new List<Buttons>();
 
     #endregion HotkeyConfig
 }

--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -80,7 +80,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public List<Keys> KeyboardSwitchAutoLoadState { get; set; } = Hotkey.SwitchAutoLoadState.GetDefaultKeys();
     public List<Keys> KeyboardSpawnTowerViewer { get; set; } = Hotkey.SpawnTowerViewer.GetDefaultKeys();
     public List<Keys> KeyboardToggleFullscreen { get; set; } = Hotkey.ToggleFullscreen.GetDefaultKeys();
-    public List<Keys> KeyboardDumpRoomTimes { get; set; } = Hotkey.DumpRoomTimes.GetDefaultKeys();
+    public List<Keys> KeyboardExportRoomTimes { get; set; } = Hotkey.ExportRoomTimes.GetDefaultKeys();
 
     public List<Buttons> ControllerToggleHotkeys { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerSaveState { get; set; } = new List<Buttons>();
@@ -101,7 +101,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public List<Buttons> ControllerSwitchAutoLoadState { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerSpawnTowerViewer { get; set; } = new List<Buttons>();
     public List<Buttons> ControllerToggleFullscreen { get; set; } = new List<Buttons>();
-    public List<Buttons> ControllerDumpRoomTimes { get; set; }  = new List<Buttons>();
+    public List<Buttons> ControllerExportRoomTimes { get; set; }  = new List<Buttons>();
 
     #endregion HotkeyConfig
 }


### PR DESCRIPTION
- **Add ability to export room timer data**
Quite a few people have been manually extracting the room timer data (current room times + pb times) from their runs into external spreadsheets, which is quite a tedious process, so by request I put together this feature to make that process significantly easier. 
The two methods of exporting are via a `Export Room Times` hotkey and a `srt_exportroomtimes` console command. The files are created in a `SRT_RoomTimeExports` folder in the game directory, and are named according to the time at which they were generated (down to the second).
I’m hoping the default UTF-8 text file encoding + the csv file extension will work fine with popular spreadsheet software across all platforms, but I only tested on Windows and MacOS with the current Excel versions for each OS - not sure what other possibilities should be checked, if any, but I wanted to avoid adding spreadsheet libraries like CSVHelper or something. Most people are looking to paste this data into Google Sheets anyway, so at worst they can just open the file with a text editor and copy paste the text, Sheets has a way to split text among columns automatically based on the comma delimiter.
- **Add best segment tracking**
Something that people asked for once I began building the export room timer data feature, which made sense to add within the context of that exporting. By (another) request, I also added a setting to turn the timer gold when a best room time is calculated - the reason I was given for wanting that was so that people could watch back their sessions to extract recordings of rooms where they got a gold, since there's no feedback otherwise. I kinda hijacked `BeatBestTime` as an easy way of getting that done, but it works as expected, and I made it a setting because I can definitely see people wanting to turn it off (myself included).