### PR TITLE
Only turn timer gold if prev. best room time wasn't 0

### DIFF
--- a/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
@@ -112,7 +112,9 @@ internal class RoomTimerData {
                     prevRoomTime = ThisRunTimes.GetValueOrDefault(thisRunPrevRoomTimeKey, 0);
                     if (Time - prevRoomTime < lastBestSegment || lastBestSegment == 0) {
                         BestSegments[thisRunTimeKey] = Time - prevRoomTime;
-                        displayGoldRenderTime = DisplayGoldRenderDelay;
+                        if (lastBestSegment != 0) {
+                            displayGoldRenderTime = DisplayGoldRenderDelay;
+                        }
                     }
 
                     // don't overflow room number at level end
@@ -136,7 +138,9 @@ internal class RoomTimerData {
                         prevRoomTime = ThisRunTimes.GetValueOrDefault(thisRunPrevRoomTimeKey, 0);
                         if (Time - prevRoomTime < lastBestSegment || lastBestSegment == 0) {
                             BestSegments[pbTimeKey] = Time - prevRoomTime;
-                            displayGoldRenderTime = DisplayGoldRenderDelay;
+                            if (lastBestSegment != 0) {
+                                displayGoldRenderTime = DisplayGoldRenderDelay;
+                            }
                         }
                     }
                 } else if (endPoint || level is {Completed: true} || EndPoint.IsReachedRoomIdEndPoint) {
@@ -151,7 +155,9 @@ internal class RoomTimerData {
                     prevRoomTime = ThisRunTimes.GetValueOrDefault(thisRunPrevRoomTimeKey, 0);
                     if (Time - prevRoomTime < lastBestSegment || lastBestSegment == 0) {
                         BestSegments[thisRunTimeKey] = Time - prevRoomTime;
-                        displayGoldRenderTime = DisplayGoldRenderDelay;
+                        if (lastBestSegment != 0) {
+                            displayGoldRenderTime = DisplayGoldRenderDelay;
+                        }
                     }
 
                     timerState = TimerState.Completed;
@@ -180,7 +186,9 @@ internal class RoomTimerData {
                     prevRoomTime = ThisRunTimes.GetValueOrDefault(thisRunPrevRoomTimeKey, 0);
                     if (Time - prevRoomTime < lastBestSegment || lastBestSegment == 0) {
                         BestSegments[thisRunTimeKey] = Time - prevRoomTime;
-                        displayGoldRenderTime = DisplayGoldRenderDelay;
+                        if (lastBestSegment != 0) {
+                            displayGoldRenderTime = DisplayGoldRenderDelay;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Prevents the first run on saving a state continually flashing the timer gold, which people found distracting and unintuitive. This doesn't technically address the concern of "if this is the first time a gold has been calculated then don’t flash timer”, it’s “if the previous gold time was 0 then don’t flash timer”, but in practice those are the same thing + if someone's gold time is a 0.000 then they cannot beat it anyway and the timer shouldn't flash gold there either.