### PR TITLE
Change ‘Auto Load State After Death’ default to false

### DIFF
--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -31,7 +31,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
 
     #region State
 
-    public bool AutoLoadStateAfterDeath { get; set; } = true;
+    public bool AutoLoadStateAfterDeath { get; set; } = false;
     public bool AutoClearStateOnScreenTransition { get; set; } = false;
     public FreezeAfterLoadStateType FreezeAfterLoadStateType { get; set; } = FreezeAfterLoadStateType.On;
     public bool NoGcAfterLoadState { get; set; } = false;


### PR DESCRIPTION
Apparently a lot of new runners use Speedrun Tool for months without realising this can be turned off, and so they form bad practice habits/think they can’t practice strats like 5B bubsdrop.

I made this change in the web editor because somebody asked for it and I didn’t have time to boot into windows