### PR TITLE
Improve autosplitter's accuracy when reading SRTool's timer

### DIFF
--- a/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerData.cs
@@ -23,6 +23,9 @@ internal class RoomTimerData {
     private bool hitEndPoint = false;
     private float displayGoldRenderTime = 0f;
     private const float DisplayGoldRenderDelay = 0.68f;
+    public long AutosplitterTime { get; private set; }
+    private float autosplitterTimeFreezeTime = 0f;
+    private const float AutosplitterTimeFreezeDelay = 0.68f;
 
     public RoomTimerData(RoomTimerType roomTimerType) {
         this.roomTimerType = roomTimerType;
@@ -84,6 +87,12 @@ internal class RoomTimerData {
         }
         
         Time += TimeSpan.FromSeconds(Engine.RawDeltaTime).Ticks;
+
+        if (autosplitterTimeFreezeTime > 0f) {
+            autosplitterTimeFreezeTime -= Engine.RawDeltaTime;
+        } else {
+            AutosplitterTime = Time;
+        }
     }
 
     public void UpdateTimerState(bool endPoint) {
@@ -214,6 +223,8 @@ internal class RoomTimerData {
         lastBestSegment = 0;
         prevRoomTime = 0;
         displayGoldRenderTime = 0f;
+        autosplitterTimeFreezeTime = 0f;
+        AutosplitterTime = Time;
         ThisRunTimes.Clear();
         hitEndPoint = false;
     }
@@ -232,5 +243,9 @@ internal class RoomTimerData {
 
         TimeSpan timeSpan = TimeSpan.FromTicks(time);
         return timeSpan.ToString(timeSpan.TotalSeconds < 60 ? "s\\.fff" : "m\\:ss\\.fff");
+    }
+
+    public void FreezeAutosplitterTime() {
+        autosplitterTimeFreezeTime = AutosplitterTimeFreezeDelay;
     }
 }

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -194,6 +194,9 @@ public static class RoomTimerManager {
         // always run both timers; they'll just run in the background if not selected
         NextRoomTimerData.UpdateTimerState(endPoint);
         CurrentRoomTimerData.UpdateTimerState(endPoint);
+
+        NextRoomTimerData.FreezeAutosplitterTime();
+        CurrentRoomTimerData.FreezeAutosplitterTime();
     }
 
     public static void ResetTime() {
@@ -318,7 +321,7 @@ public static class RoomTimerManager {
         if (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdfld<Session>("Time"))) {
             cursor.EmitDelegate<Func<long, long>>((origTime) => {
                 if (ModSettings.Enabled && ModSettings.RoomTimerType is not RoomTimerType.Off) {
-                    return (ModSettings.RoomTimerType is RoomTimerType.NextRoom) ? NextRoomTimerData.Time : CurrentRoomTimerData.Time;
+                    return (ModSettings.RoomTimerType is RoomTimerType.NextRoom) ? NextRoomTimerData.AutosplitterTime : CurrentRoomTimerData.AutosplitterTime;
                 }
                 return origTime;
             });


### PR DESCRIPTION
Even at absurdly high refresh rates (>240hz), Livesplit/the autosplitter frequently is off by usually 1-2 frames (sometimes as high as 4 frames at lower refresh rates) when recording splits. Freezing the timer read by the autosplitter for a few frames on potential split events allows it to catch up when its update rate falls behind. This improved accuracy to 100% across 10 minutes of gameplay with no noticeable side effects. 

This obviously does nothing to fix the inherent issue here so it's still present when not using SRTool's timer, but since we're already overwriting the autosplitter timer when SRTool's timer is active I figured it'd be reasonable to implement the hack here.