### PR TITLE
Fix the strawberry counter overlapping the room timer

### DIFF
--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -46,6 +46,7 @@ public static class RoomTimerManager {
         On.Celeste.SaveData.RegisterCassette += SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor += LevelExitOnCtor;
         IL.Celeste.AutoSplitterInfo.Update += OverwriteAutosplitterChapterTime;
+        IL.Celeste.TotalStrawberriesDisplay.Update += MoveStrawberryDisplayDown;
         TryTurnOffRoomTimer();
         RegisterHotkeys();
     }
@@ -60,6 +61,7 @@ public static class RoomTimerManager {
         On.Celeste.SaveData.RegisterCassette -= SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor -= LevelExitOnCtor;
         IL.Celeste.AutoSplitterInfo.Update -= OverwriteAutosplitterChapterTime;
+        IL.Celeste.TotalStrawberriesDisplay.Update -= MoveStrawberryDisplayDown;
     }
 
     private static void RegisterHotkeys() {
@@ -312,6 +314,20 @@ public static class RoomTimerManager {
             font.DrawOutline(fontFaceSize, ch.ToString(), new Vector2(x + num2 / 2f, y), new Vector2(0.5f, 1f),
                 Vector2.One * currentScale, color3, 2f, Color.Black);
             x += num2;
+        }
+    }
+
+    private static void MoveStrawberryDisplayDown(ILContext il) {
+        ILCursor cursor = new(il);
+
+        // If the room timer is visible, push the strawberry display down so that it doesn't overlap the timer
+        if (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchCall<Engine>("get_DeltaTime") && instr.Next.MatchLdcR4(800))) {
+            cursor.EmitDelegate<Func<float, float>>((origTargetPos) => {
+                if (ModSettings.Enabled && ModSettings.RoomTimerType is not RoomTimerType.Off) {
+                    return 174f; // Same as regular file timer
+                }
+                return origTargetPos;
+            });
         }
     }
 


### PR DESCRIPTION
The `TotalStrawberriesDisplay` calculates its render position based on what the current vanilla timer type is and was thus rendering over the top of the room timer depending on what that setting was currently set to. This just overwrites the value of that render position if the room timer is currently on. Before and after videos attached for reference

https://github.com/DemoJameson/CelesteSpeedrunTool/assets/72244655/52b7fb7f-b23a-482c-b92e-4ba78137f529


https://github.com/DemoJameson/CelesteSpeedrunTool/assets/72244655/6858d455-096e-493f-bd6d-cb51cb96ac8e

