### PR TITLE
新功能：更多存档槽

### DIFF
--- a/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
+++ b/SpeedrunTool/Source/SaveLoad/SaveLoadAction.cs
@@ -591,8 +591,7 @@ public sealed class SaveLoadAction {
                 ClearBeforeSaveComponent.RemoveAll(level);
 
                 // 冲刺残影方向错误，干脆移除屏幕不显示了
-                level.Tracker.GetEntities<TrailManager.Snapshot>()
-                    .ForEach(entity => entity.Position = level.Camera.Position - Vector2.One * 100);
+                TrailManager.Clear();
 
                 if (ModUtils.IsInstalled("CelesteNet.Client")) {
                     Type ghostEmoteWheelType = ModUtils.GetType("CelesteNet.Client", "Celeste.Mod.CelesteNet.Client.Entities.GhostEmoteWheel");


### PR DESCRIPTION
这个 PR 有点借鸡生蛋的意思, SRT 的仓库太大了, 我好像没法把它的提交记录完整克隆下来, 所以开了个新的仓库 https://github.com/LozenChen/SRT, 里面则是真正想要 PR 的内容, 其提交记录应该能比较好地反映修改了的内容, 主要需要关注的只有 `StateManager, SaveLoadAction, SaveSlotsManager` 三个类

**功能**：字面意思, 使得用户能够有更多存档槽, 可以在多处分别存档, 然后读档

**实现的大致思路**：将 `StateManager 的一个实例 + SaveLoadAction.All` 合起来包装成一个新的对象 `SaveSlot`, 用一个 `SaveSlotsManager` 类管理当前正在使用的存档槽, 然后对原来引用的 `StateManager` 实例与 `SaveLoadAction.All` 的地方, 让他们重定向至 `SaveSlot.StateManager/All`, 这样就在基本不改变原先架构的前提下, 实现了此功能

目前没找到比较恶性的 bug, 不过一些依赖于 SRT 的 mod 需要小幅度修改, 例如 CelesteTAS 的 `Savestates` 类, 现在应该将原本指向 `StateManager.Instance` 的地方, 全指向 tas 存档槽所对应的 StateManager

=============================

**存在的问题**：`SaveLoadAction.SafeAdd` 方法, 目前是仅仅指向正在用的存档槽, 对于在 SaveLoadAction 类内部初始化时调用的 SafeAdd, 这无所谓, 因为下一个存档槽初始化的时候还会再调用 SafeAdd. 但是对于 SaveLoadAction 类外部调用的 SafeAdd, 它们就很有可能只添加到了一个存档槽上. 注意到第三方 mod 通过 ModInterop 来支持 SRT 的时候, 也是调用 SafeAdd.

**可能的解决办法**

(a). 假定在 mod 初始化期间就已经决定好一共有多少个存档槽 (包括其他 mod 申请专用的存档槽), 然后 SafeAdd 直接对每个存档槽都加上. 呃这个方法除了看起来不太优雅, 应该很稳定好用.

(b). SafeAdd 现在加到一个静态的 All 当中, 然后每个存档槽初始化的时候, 都将这个 All 克隆到存档槽自己的 All 上. 问题是这样做之后, 似乎会导致存读档之后, 镜头无法跟随玩家正常切板, 贴图丢失.

=============================

**其他的问题**：如果要支持多存档槽, 那么 SafeAdd 里就必须将数据真正存储到 saveAction 参数的那个 Dictionary 当中. 而目前部分 mod 都只是将数据存到自己的一个静态类当中的. 因此其他 mod 必须做出相应的修改. (比如 CelesteTAS)

此外, 目前为了最大限度不修改 TAS 侧的代码, SRT 对 TAS 的支持写的说实话有点丑. 两个 mod 同时改写的话, 应该会好一些.