### PR TITLE
fix: motion-smoothing compatibility

### DIFF
--- a/SpeedrunTool/Source/SaveLoad/ThirdPartySupport/MotionSmoothingFix.cs
+++ b/SpeedrunTool/Source/SaveLoad/ThirdPartySupport/MotionSmoothingFix.cs
@@ -1,5 +1,6 @@
 using Celeste.Mod.SpeedrunTool.Utils;
 using Mono.Cecil.Cil;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Celeste.Mod.SpeedrunTool.SaveLoad.ThirdPartySupport;
@@ -25,6 +26,19 @@ internal static class MotionSmoothingFix {
             MotionSmoothingInstalled = true;
             handler = motionSmoothHandler;
             method = smoothAll;
+
+            // Remove MotionSmoothing's action from the SharedActions list
+           FieldInfo sharedActionsField = typeof(SaveLoadAction).GetField("SharedActions", BindingFlags.Static | BindingFlags.NonPublic);
+            if (sharedActionsField?.GetValue(null) is List<SaveLoadAction> sharedActions) {
+                foreach (SaveLoadAction action in sharedActions) {
+                    if (action.GetType().GetField("loadState", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(action) is Delegate loadStateDelegate) {
+                        if (loadStateDelegate.Target?.GetType().Assembly.GetName().Name == "MotionSmoothing") {
+                            sharedActions.Remove(action);
+                            break;
+                        }
+                    }
+                };
+            }
 
             // the original one is a method call of a singleton, which may be wrong after deepclone?
             // (note save load actions are deepcloned to each save slot)

--- a/SpeedrunTool/Source/SaveLoad/ThirdPartySupport/MotionSmoothingFix.cs
+++ b/SpeedrunTool/Source/SaveLoad/ThirdPartySupport/MotionSmoothingFix.cs
@@ -28,7 +28,7 @@ internal static class MotionSmoothingFix {
             method = smoothAll;
 
             // Remove MotionSmoothing's action from the SharedActions list
-           FieldInfo sharedActionsField = typeof(SaveLoadAction).GetField("SharedActions", BindingFlags.Static | BindingFlags.NonPublic);
+            FieldInfo sharedActionsField = typeof(SaveLoadAction).GetField("SharedActions", BindingFlags.Static | BindingFlags.NonPublic);
             if (sharedActionsField?.GetValue(null) is List<SaveLoadAction> sharedActions) {
                 foreach (SaveLoadAction action in sharedActions) {
                     if (action.GetType().GetField("loadState", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(action) is Delegate loadStateDelegate) {


### PR DESCRIPTION
Removes motion-smoothing's SaveLoad hook if it has already been registered.

This should address the crashes that occur when motion-smoothing is installed.