### PR TITLE
Feature: added More Options/Allow Save During Death

### DIFF
--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -133,6 +133,7 @@ SPEEDRUN_TOOL_SAVE_TO_NEXT_SLOT=             Save to Next Available Slot
 SPEEDRUN_TOOL_LOAD_FROM_LAST_SLOT=           Load from Last Available Slot
 SPEEDRUN_TOOL_SWItCH_TO_NEXT_SLOT=           Switch to Next Slot
 SPEEDRUN_TOOL_SWITCH_TO_PREVIOUS_SLOT=       Switch to Previous Slot
+
 SPEEDRUN_TOOL_TOGGLE_SAVE_LOAD_UI=           Toggle SaveLoad UI
 
 # ================================== Death Statistics ==================================
@@ -158,6 +159,7 @@ SPEEDRUN_TOOL_RESPAWN_SPEED=                       Respawn Speed
 SPEEDRUN_TOOL_RESTART_CHAPTER_SPEED=               Restart Chapter Speed
 SPEEDRUN_TOOL_SKIP_RESTART_CHAPTER_SCREEN_WIPE=    Skip Restart Chapter Screen Wipe
 SPEEDRUN_TOOL_ALLOW_PAUSE_DURING_DEATH=            Allow Pause during Death
+SPEEDRUN_TOOL_ALLOW_SAVE_DURING_DEATH=             Allow Save during Death
 SPEEDRUN_TOOL_MUTE_IN_BACKGROUND=                  Mute in Background
 SPEEDRUN_TOOL_FIX_CORE_REFILL_DASH_AFTER_TELEPORT= Fix Core Refill Dash after Teleport
 SPEEDRUN_TOOL_POPUP_MESSAGE_STYLE=                 Pop-up Message Style

--- a/SpeedrunTool/Dialog/Simplified Chinese.txt
+++ b/SpeedrunTool/Dialog/Simplified Chinese.txt
@@ -135,6 +135,7 @@ SPEEDRUN_TOOL_SAVE_TO_NEXT_SLOT=             存至下一存档槽
 SPEEDRUN_TOOL_LOAD_FROM_LAST_SLOT=           读取上一存档槽
 SPEEDRUN_TOOL_SWITCH_TO_NEXT_SLOT=           切换至下一存档槽
 SPEEDRUN_TOOL_SWITCH_TO_PREVIOUS_SLOT=       切换至上一存档槽
+
 SPEEDRUN_TOOL_TOGGLE_SAVE_LOAD_UI=           开关存读档用户界面
 
 # ================================== Death Statistics ==================================
@@ -159,6 +160,8 @@ SPEEDRUN_TOOL_RESPAWN_SPEED=                       复活速度
 SPEEDRUN_TOOL_RESTART_CHAPTER_SPEED=               重启章节速度
 SPEEDRUN_TOOL_SKIP_RESTART_CHAPTER_SCREEN_WIPE=    跳过重启章节的黑屏动画
 SPEEDRUN_TOOL_ALLOW_PAUSE_DURING_DEATH=            允许死亡时暂停
+SPEEDRUN_TOOL_ALLOW_SAVE_DURING_DEATH=             允许死亡时保存
+# ^ please correct this if it's wrong, i don't speak chinese
 SPEEDRUN_TOOL_MUTE_IN_BACKGROUND=                  游戏后台运行时静音
 SPEEDRUN_TOOL_FIX_CORE_REFILL_DASH_AFTER_TELEPORT= 修正第八章传送后冲刺恢复异常
 SPEEDRUN_TOOL_POPUP_MESSAGE_STYLE=                 提示信息样式

--- a/SpeedrunTool/Dialog/Simplified Chinese.txt
+++ b/SpeedrunTool/Dialog/Simplified Chinese.txt
@@ -135,7 +135,6 @@ SPEEDRUN_TOOL_SAVE_TO_NEXT_SLOT=             存至下一存档槽
 SPEEDRUN_TOOL_LOAD_FROM_LAST_SLOT=           读取上一存档槽
 SPEEDRUN_TOOL_SWITCH_TO_NEXT_SLOT=           切换至下一存档槽
 SPEEDRUN_TOOL_SWITCH_TO_PREVIOUS_SLOT=       切换至上一存档槽
-
 SPEEDRUN_TOOL_TOGGLE_SAVE_LOAD_UI=           开关存读档用户界面
 
 # ================================== Death Statistics ==================================
@@ -161,7 +160,6 @@ SPEEDRUN_TOOL_RESTART_CHAPTER_SPEED=               重启章节速度
 SPEEDRUN_TOOL_SKIP_RESTART_CHAPTER_SCREEN_WIPE=    跳过重启章节的黑屏动画
 SPEEDRUN_TOOL_ALLOW_PAUSE_DURING_DEATH=            允许死亡时暂停
 SPEEDRUN_TOOL_ALLOW_SAVE_DURING_DEATH=             允许死亡时保存
-# ^ please correct this if it's wrong, i don't speak chinese
 SPEEDRUN_TOOL_MUTE_IN_BACKGROUND=                  游戏后台运行时静音
 SPEEDRUN_TOOL_FIX_CORE_REFILL_DASH_AFTER_TELEPORT= 修正第八章传送后冲刺恢复异常
 SPEEDRUN_TOOL_POPUP_MESSAGE_STYLE=                 提示信息样式
@@ -175,3 +173,4 @@ SPEEDRUN_TOOL_CLIPBOARD=                           剪贴板
 SPEEDRUN_TOOL_HOTKEYS=                             快捷键
 SPEEDRUN_TOOL_HOTKEYS_CONFIG=                      快捷键设置
 SPEEDRUN_TOOL_UNLOCK_CAMERA=                       解锁镜头
+

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -131,6 +131,7 @@ public static class DialogIds {
     public const string LoadFromLastSlot = "SPEEDRUN_TOOL_LOAD_FROM_LAST_SLOT";
     public const string SwitchToNextSlot = "SPEEDRUN_TOOL_SWITCH_TO_NEXT_SLOT";
     public const string SwitchToPreviousSlot = "SPEEDRUN_TOOL_SWITCH_TO_PREVIOUS_SLOT";
+
     public const string ToggleSaveLoadUI = "SPEEDRUN_TOOL_TOGGLE_SAVE_LOAD_UI";
 
     // Death Statistics
@@ -154,6 +155,7 @@ public static class DialogIds {
     public const string RestartChapterSpeed = "SPEEDRUN_TOOL_RESTART_CHAPTER_SPEED";
     public const string SkipRestartChapterScreenWipe = "SPEEDRUN_TOOL_SKIP_RESTART_CHAPTER_SCREEN_WIPE";
     public const string AllowPauseDuringDeath = "SPEEDRUN_TOOL_ALLOW_PAUSE_DURING_DEATH";
+    public const string AllowSaveDuringDeath = "SPEEDRUN_TOOL_ALLOW_SAVE_DURING_DEATH";
     public const string MuteInBackground = "SPEEDRUN_TOOL_MUTE_IN_BACKGROUND";
     public const string FixCoreRefillDashAfterTeleport = "SPEEDRUN_TOOL_FIX_CORE_REFILL_DASH_AFTER_TELEPORT";
     public const string PopupMessageStyle = "SPEEDRUN_TOOL_POPUP_MESSAGE_STYLE";

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -131,7 +131,6 @@ public static class DialogIds {
     public const string LoadFromLastSlot = "SPEEDRUN_TOOL_LOAD_FROM_LAST_SLOT";
     public const string SwitchToNextSlot = "SPEEDRUN_TOOL_SWITCH_TO_NEXT_SLOT";
     public const string SwitchToPreviousSlot = "SPEEDRUN_TOOL_SWITCH_TO_PREVIOUS_SLOT";
-
     public const string ToggleSaveLoadUI = "SPEEDRUN_TOOL_TOGGLE_SAVE_LOAD_UI";
 
     // Death Statistics

--- a/SpeedrunTool/Source/SaveLoad/StateManager.cs
+++ b/SpeedrunTool/Source/SaveLoad/StateManager.cs
@@ -616,7 +616,7 @@ public sealed class StateManager {
             failReason = "Cannot Save while Level is Paused!";
             return false;
         }
-        if (level.IsPlayerDead()) {
+        if (!ModSettings.AllowSaveDuringDeath && level.IsPlayerDead()) {
             failReason = "Cannot Save while Player is Dead!";
             return false;
         }
@@ -701,4 +701,5 @@ public enum State {
     Saving,
     Loading,
     Waiting,
+
 }

--- a/SpeedrunTool/Source/SpeedrunToolMenu.cs
+++ b/SpeedrunTool/Source/SpeedrunToolMenu.cs
@@ -217,6 +217,9 @@ public static class SpeedrunToolMenu {
             subMenu.Add(new TextMenu.OnOff(Dialog.Clean(DialogIds.AllowPauseDuringDeath), ModSettings.AllowPauseDuringDeath).Change(b =>
                 ModSettings.AllowPauseDuringDeath = b));
 
+            subMenu.Add(new TextMenu.OnOff(Dialog.Clean(DialogIds.AllowSaveDuringDeath), ModSettings.AllowSaveDuringDeath).Change(b =>
+                ModSettings.AllowSaveDuringDeath = b));
+
             subMenu.Add(
                 new TextMenu.OnOff(Dialog.Clean(DialogIds.MuteInBackground), ModSettings.MuteInBackground).Change(b =>
                     ModSettings.MuteInBackground = b));
@@ -321,6 +324,7 @@ internal class EaseInSubMenu : TextMenuExt.SubMenu {
         if (outline) {
             icon.DrawOutlineCentered(position + justify, color, scale);
         }
+
         else {
             icon.DrawCentered(position + justify, color, scale);
         }

--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -84,6 +84,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public int RestartChapterSpeed { get; set; } = 1;
     public bool SkipRestartChapterScreenWipe { get; set; } = false;
     public bool AllowPauseDuringDeath { get; set; } = false;
+    public bool AllowSaveDuringDeath { get; set; } = false;
     public bool MuteInBackground { get; set; } = false;
     public bool FixCoreRefillDashAfterTeleport { get; set; } = true;
     public PopupMessageStyle PopupMessageStyle { get; set; } = PopupMessageStyle.Tooltip;
@@ -183,6 +184,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
     public List<Buttons> ControllerLoadFromLastSlot { get; set; } = new List<Buttons>();
 
     public List<Buttons> ControllerToggleSaveLoadUI { get; set; } = new List<Buttons>();
+
 
 
     #endregion HotkeyConfig


### PR DESCRIPTION
I've added an option that allows you to create a savestate while the player is dead, which is useful in certain edgecases like limbo (https://gamebanana.com/mods/632731).

I have no idea why or how the edit history got messed up and showed almost the entirety of the document edited, all i did was add a handful of lines and edit one single line.

You may need to correct the edit in the Simplified Chinese localisation, as i can't speak it.