### PR TITLE
Feature: Added an option under State that allows savestating while dead

### DIFF
--- a/SpeedrunTool/Dialog/English.txt
+++ b/SpeedrunTool/Dialog/English.txt
@@ -68,6 +68,7 @@ SPEEDRUN_TOOL_CLEAR_STATE_DIALOG_BADELINE=
 SPEEDRUN_TOOL_NOT_SAVED_STATE_YET_DIALOG_BADELINE=
     [BADELINE left yell]
     Not saved state yet!
+SPEEDRUN_TOOL_ALLOW_STATE_DURING_DEATH=    Allow State during Death
 
 # ================================== End Point Style ==================================
 SPEEDRUN_TOOL_FLAG=       Flag

--- a/SpeedrunTool/Dialog/Simplified Chinese.txt
+++ b/SpeedrunTool/Dialog/Simplified Chinese.txt
@@ -70,6 +70,7 @@ SPEEDRUN_TOOL_CLEAR_STATE_DIALOG_BADELINE=
 SPEEDRUN_TOOL_NOT_SAVED_STATE_YET_DIALOG_BADELINE=
     [BADELINE left yell]
     还没保存状态！
+SPEEDRUN_TOOL_ALLOW_STATE_DURING_DEATH=    允许死亡时状态
 
 # ================================== End Point Style ==================================
 SPEEDRUN_TOOL_FLAG=      Flag

--- a/SpeedrunTool/Source/DialogIds.cs
+++ b/SpeedrunTool/Source/DialogIds.cs
@@ -70,6 +70,7 @@ public static class DialogIds {
     public const string NotSavedStateYetDialogBadeline = "SPEEDRUN_TOOL_NOT_SAVED_STATE_YET_DIALOG_BADELINE";
     public const string NoMessageAfterSaveLoad = "SPEEDRUN_TOOL_NO_MESSAGE_AFTER_SAVE_LOAD";
     public const string NoMessageAfterSaveLoadDescription = "SPEEDRUN_TOOL_NO_MESSAGE_AFTER_SAVE_LOAD_DESCRIPTION";
+    public const string AllowStateDuringDeath = "SPEEDRUN_TOOL_ALLOW_STATE_DURING_DEATH";
 
     // End Point Style
     public const string Flag = "SPEEDRUN_TOOL_FLAG";

--- a/SpeedrunTool/Source/SaveLoad/StateManager.cs
+++ b/SpeedrunTool/Source/SaveLoad/StateManager.cs
@@ -616,7 +616,7 @@ public sealed class StateManager {
             failReason = "Cannot Save while Level is Paused!";
             return false;
         }
-        if (level.IsPlayerDead()) {
+        if (level.IsPlayerDead() && !ModSettings.AllowStateDuringDeath) {
             failReason = "Cannot Save while Player is Dead!";
             return false;
         }

--- a/SpeedrunTool/Source/SpeedrunToolMenu.cs
+++ b/SpeedrunTool/Source/SpeedrunToolMenu.cs
@@ -173,6 +173,9 @@ public static class SpeedrunToolMenu {
                 ModSettings.NoMessageAfterSaveLoad = b));
             AddDescription(noMessageAfterSaveLoad, subMenu, menu, Dialog.Clean(DialogIds.NoMessageAfterSaveLoadDescription));
 
+            subMenu.Add(new TextMenu.OnOff(Dialog.Clean(DialogIds.AllowStateDuringDeath), ModSettings.AllowStateDuringDeath).Change(b =>
+                ModSettings.AllowStateDuringDeath = b));
+
         });
     }
 

--- a/SpeedrunTool/Source/SpeedrunToolSettings.cs
+++ b/SpeedrunTool/Source/SpeedrunToolSettings.cs
@@ -68,6 +68,7 @@ public class SpeedrunToolSettings : EverestModuleSettings {
 
     public bool SaveInLuaCutscene { get; set; } = false;
     public bool NoMessageAfterSaveLoad { get; set; } = false;
+    public bool AllowStateDuringDeath { get; set; } = false;
 
     #endregion
 


### PR DESCRIPTION
This is useful for limbo or other edgecases that allow gameplay while the player is dead.

I can send a list of changes if you want since GitHub's change logger doesn't work correctly here for some reason.