### PR TITLE
Fix autosplitter overwrite for Everest Core

### DIFF
--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -46,7 +46,6 @@ public static class RoomTimerManager {
         On.Celeste.HeartGem.RegisterAsCollected += HeartGemOnRegisterAsCollected;
         On.Celeste.SaveData.RegisterCassette += SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor += LevelExitOnCtor;
-        IL.Celeste.AutoSplitterInfo.Update += OverwriteAutosplitterChapterTime;
         IL.Celeste.TotalStrawberriesDisplay.Update += MoveStrawberryDisplayDown;
         TryTurnOffRoomTimer();
         RegisterHotkeys();
@@ -61,7 +60,6 @@ public static class RoomTimerManager {
         On.Celeste.HeartGem.RegisterAsCollected -= HeartGemOnRegisterAsCollected;
         On.Celeste.SaveData.RegisterCassette -= SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor -= LevelExitOnCtor;
-        IL.Celeste.AutoSplitterInfo.Update -= OverwriteAutosplitterChapterTime;
         IL.Celeste.TotalStrawberriesDisplay.Update -= MoveStrawberryDisplayDown;
     }
 
@@ -335,19 +333,6 @@ public static class RoomTimerManager {
     public static void TryTurnOffRoomTimer() {
         if (ModSettings.AutoResetRoomTimer) {
             SwitchRoomTimer(RoomTimerType.Off);
-        }
-    }
-
-    private static void OverwriteAutosplitterChapterTime(ILContext il) {
-        ILCursor cursor = new(il);
-
-        if (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdfld<Session>("Time"))) {
-            cursor.EmitDelegate<Func<long, long>>((origTime) => {
-                if (ModSettings.Enabled && ModSettings.RoomTimerType is not RoomTimerType.Off) {
-                    return Data_Auto.AutosplitterTime;
-                }
-                return origTime;
-            });
         }
     }
 

--- a/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
+++ b/SpeedrunTool/Source/RoomTimer/RoomTimerManager.cs
@@ -47,6 +47,7 @@ public static class RoomTimerManager {
         On.Celeste.SaveData.RegisterCassette += SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor += LevelExitOnCtor;
         IL.Celeste.TotalStrawberriesDisplay.Update += MoveStrawberryDisplayDown;
+        AutoSplitter.OnUpdateInfo += OverwriteAutosplitterChapterTime;
         TryTurnOffRoomTimer();
         RegisterHotkeys();
     }
@@ -61,6 +62,7 @@ public static class RoomTimerManager {
         On.Celeste.SaveData.RegisterCassette -= SaveDataOnRegisterCassette;
         On.Celeste.LevelExit.ctor -= LevelExitOnCtor;
         IL.Celeste.TotalStrawberriesDisplay.Update -= MoveStrawberryDisplayDown;
+        AutoSplitter.OnUpdateInfo -= OverwriteAutosplitterChapterTime;
     }
 
     private static void RegisterHotkeys() {
@@ -333,6 +335,12 @@ public static class RoomTimerManager {
     public static void TryTurnOffRoomTimer() {
         if (ModSettings.AutoResetRoomTimer) {
             SwitchRoomTimer(RoomTimerType.Off);
+        }
+    }
+
+    private static void OverwriteAutosplitterChapterTime(ref AutoSplitter.CoreAutoSplitterInfo info, Func<string, nint> stringWriter) {
+        if (ModSettings.Enabled && ModSettings.RoomTimerType is not RoomTimerType.Off) {
+            info.ChapterTime = Data_Auto.AutosplitterTime;
         }
     }
 


### PR DESCRIPTION
No longer works since update to NET Core, as Everest introduced its own [autosplitter info](https://github.com/EverestAPI/Everest/blob/dev/Celeste.Mod.mm/Mod/Everest/AutoSplitter.cs) which Livesplit looks for instead of vanilla's.

I plan to open a PR in Everest that adds the ability for mods to overwrite info so that this functionality can be reintroduced here, but will wait till that hits stable.